### PR TITLE
It would be nice to be able to set the timeout via a Timespan, so that intent of the number is more clear.

### DIFF
--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -162,6 +162,11 @@ namespace SimpleBrowser
                 }
             }
         }
+        
+        /// <summary>
+        /// Sets the default browser timeout to this timespan. Must be > 0 milliseconds..
+        /// </summary>
+        public void SetTimeout(Timespan timeout)=>Timeout=timeout.TotalMilliseconds;
 
         /// <summary>
         /// Gets or sets the browser culture.

--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -166,7 +166,7 @@ namespace SimpleBrowser
         /// <summary>
         /// Sets the default browser timeout to this timespan. Must be > 0 milliseconds..
         /// </summary>
-        public void SetTimeout(Timespan timeout)=>Timeout=timeout.TotalMilliseconds;
+        public void SetTimeout(Timespan timeout)=>Timeout=(int)timeout.TotalMilliseconds;
 
         /// <summary>
         /// Gets or sets the browser culture.


### PR DESCRIPTION
setting the Timeout via Timespan is more explicit - Timeout=600 -- is that less than 1 second, or do i have 5 minutes to download the file?

 browser.Timeout = (int)TimeSpan.FromSeconds(600).TotalMilliseconds; is how this has to be expressed, but i thought that switching this to Timespan would be better. That would be a breaking change, so this PR proposes an alternate setter.